### PR TITLE
Fix remaining 41 bugs across all subsystems documented in Docs/bugs.md

### DIFF
--- a/ProSSHMac/AppIntents/ProSSHShortcuts.swift
+++ b/ProSSHMac/AppIntents/ProSSHShortcuts.swift
@@ -1,7 +1,7 @@
 import Foundation
 import AppIntents
 
-@available(iOS 16.0, *)
+@available(macOS 13.0, *)
 enum ProSSHSectionOption: String, AppEnum {
     case hosts
     case terminal
@@ -39,7 +39,7 @@ enum ProSSHSectionOption: String, AppEnum {
     }
 }
 
-@available(iOS 16.0, *)
+@available(macOS 13.0, *)
 struct OpenProSSHSectionIntent: AppIntent {
     static let title: LocalizedStringResource = "Open ProSSH Section"
     static let description = IntentDescription("Open ProSSH directly to a specific section.")
@@ -81,7 +81,7 @@ struct OpenProSSHSectionIntent: AppIntent {
     }
 }
 
-@available(iOS 16.0, *)
+@available(macOS 13.0, *)
 struct ConnectHostShortcutIntent: AppIntent {
     static let title: LocalizedStringResource = "Connect Host in ProSSH"
     static let description = IntentDescription("Open ProSSH and connect to a host by label or hostname.")
@@ -111,7 +111,7 @@ struct ConnectHostShortcutIntent: AppIntent {
     }
 }
 
-@available(iOS 16.0, *)
+@available(macOS 13.0, *)
 struct ProSSHShortcutsProvider: AppShortcutsProvider {
     static var appShortcuts: [AppShortcut] {
         AppShortcut(

--- a/ProSSHMac/Services/PortForwardingManager.swift
+++ b/ProSSHMac/Services/PortForwardingManager.swift
@@ -184,7 +184,7 @@ final class PortForwardingManager: ObservableObject {
     }
 }
 
-final class ForwardConnectionProxy: @unchecked Sendable {
+actor ForwardConnectionProxy {
     private let connection: NWConnection
     private let channel: any SSHForwardChannel
     private var localToRemoteTask: Task<Void, Never>?
@@ -196,7 +196,7 @@ final class ForwardConnectionProxy: @unchecked Sendable {
         self.channel = channel
     }
 
-    func start(onComplete: @escaping @Sendable () -> Void) async {
+    func start(onComplete: @escaping @Sendable () -> Void) {
         connection.start(queue: DispatchQueue(label: "prosshv2.fwdproxy.\(ObjectIdentifier(self))"))
 
         localToRemoteTask = Task { [weak self] in
@@ -253,7 +253,7 @@ final class ForwardConnectionProxy: @unchecked Sendable {
         }
     }
 
-    private func receiveFromConnection() async throws -> Data? {
+    private nonisolated func receiveFromConnection() async throws -> Data? {
         try await withCheckedThrowingContinuation { continuation in
             connection.receive(minimumIncompleteLength: 1, maximumLength: 32768) { content, _, isComplete, error in
                 if let error {
@@ -269,7 +269,7 @@ final class ForwardConnectionProxy: @unchecked Sendable {
         }
     }
 
-    private func sendToConnection(_ data: Data) async throws {
+    private nonisolated func sendToConnection(_ data: Data) async throws {
         try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
             connection.send(content: data, completion: .contentProcessed { error in
                 if let error {

--- a/ProSSHMac/Services/SecureEnclaveKeyManager.swift
+++ b/ProSSHMac/Services/SecureEnclaveKeyManager.swift
@@ -267,8 +267,8 @@ nonisolated final class SecureEnclaveKeyManager {
     }
 
     private func cfErrorMessage(_ error: Unmanaged<CFError>?) -> String? {
-        guard let error else { return nil }
-        let managed = error.takeRetainedValue()
-        return managed.localizedDescription
+        return error
+            .map { $0.takeRetainedValue() as CFError }
+            .map { ($0 as Error).localizedDescription }
     }
 }

--- a/ProSSHMac/Terminal/Effects/PromptAppearance.swift
+++ b/ProSSHMac/Terminal/Effects/PromptAppearance.swift
@@ -96,12 +96,16 @@ struct PromptAppearanceConfiguration: Codable, Sendable, Equatable {
             usernameStr = "%{\u{1b}[38;2;\(r);\(g);\(b)m%}\(user)%{\u{1b}[0m%}"
         case .rainbow:
             var parts = [String]()
-            for (i, char) in user.enumerated() {
-                let c = rainbowColors[i % rainbowColors.count]
-                let (r, g, b) = c.rgb255
-                parts.append("%{\u{1b}[38;2;\(r);\(g);\(b)m%}\(char)")
+            if !rainbowColors.isEmpty {
+                for (i, char) in user.enumerated() {
+                    let c = rainbowColors[i % rainbowColors.count]
+                    let (r, g, b) = c.rgb255
+                    parts.append("%{\u{1b}[38;2;\(r);\(g);\(b)m%}\(char)")
+                }
+                usernameStr = parts.joined() + "%{\u{1b}[0m%}"
+            } else {
+                usernameStr = "%F{255}\(user)%f"
             }
-            usernameStr = parts.joined() + "%{\u{1b}[0m%}"
         }
 
         let (pr, pg, pb) = pathColor.rgb255
@@ -124,12 +128,16 @@ struct PromptAppearanceConfiguration: Codable, Sendable, Equatable {
             usernameStr = "\\[\\e[38;2;\(r);\(g);\(b)m\\]\(user)\\[\\e[0m\\]"
         case .rainbow:
             var parts = [String]()
-            for (i, char) in user.enumerated() {
-                let c = rainbowColors[i % rainbowColors.count]
-                let (r, g, b) = c.rgb255
-                parts.append("\\[\\e[38;2;\(r);\(g);\(b)m\\]\(char)")
+            if !rainbowColors.isEmpty {
+                for (i, char) in user.enumerated() {
+                    let c = rainbowColors[i % rainbowColors.count]
+                    let (r, g, b) = c.rgb255
+                    parts.append("\\[\\e[38;2;\(r);\(g);\(b)m\\]\(char)")
+                }
+                usernameStr = parts.joined() + "\\[\\e[0m\\]"
+            } else {
+                usernameStr = "\\[\\e[38;2;255;255;255m\\]\(user)\\[\\e[0m\\]"
             }
-            usernameStr = parts.joined() + "\\[\\e[0m\\]"
         }
 
         let (pr, pg, pb) = pathColor.rgb255

--- a/ProSSHMac/Terminal/Features/QuickCommands.swift
+++ b/ProSSHMac/Terminal/Features/QuickCommands.swift
@@ -8,10 +8,22 @@ import Foundation
 import Combine
 
 struct QuickCommandVariable: Identifiable, Codable, Hashable, Sendable {
+    let id: UUID
     var name: String
     var defaultValue: String
 
-    var id: String { name }
+    init(name: String, defaultValue: String) {
+        self.id = UUID()
+        self.name = name
+        self.defaultValue = defaultValue
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.id = (try? container.decode(UUID.self, forKey: .id)) ?? UUID()
+        self.name = try container.decode(String.self, forKey: .name)
+        self.defaultValue = try container.decode(String.self, forKey: .defaultValue)
+    }
 }
 
 struct QuickCommandSnippet: Identifiable, Codable, Hashable, Sendable {

--- a/ProSSHMac/Terminal/Features/TerminalSearch.swift
+++ b/ProSSHMac/Terminal/Features/TerminalSearch.swift
@@ -89,6 +89,23 @@ final class TerminalSearch: ObservableObject {
         selectedMatch == match
     }
 
+    /// Validates that a match range is still within bounds for the given line content.
+    /// Returns true if the match can be safely applied.
+    func isMatchValid(_ match: TerminalSearchMatch, in currentLines: [String]) -> Bool {
+        guard match.lineIndex >= 0, match.lineIndex < currentLines.count else {
+            return false
+        }
+        let line = currentLines[match.lineIndex]
+        let lineLength = (line as NSString).length
+        let endLocation = match.location + match.length
+        return match.location >= 0 && endLocation <= lineLength
+    }
+
+    /// Returns only those matches whose ranges are still valid against the given live content.
+    func validMatches(for currentLines: [String]) -> [TerminalSearchMatch] {
+        matches.filter { isMatchValid($0, in: currentLines) }
+    }
+
     private func refreshMatches() {
         let previousSelection = selectedMatch
         matches.removeAll(keepingCapacity: true)

--- a/ProSSHMac/Terminal/Grid/TerminalGrid.swift
+++ b/ProSSHMac/Terminal/Grid/TerminalGrid.swift
@@ -510,7 +510,9 @@ actor TerminalGrid {
                 dirtyRowLo = min(dirtyRowLo, row)
                 dirtyRowHi = max(dirtyRowHi, row)
 
-                lastPrintedChar = Self.asciiCharacterCache[Int(byte)]
+                lastPrintedChar = needsCharsetMapping
+                    ? charStr.first ?? Self.asciiCharacterCache[Int(byte)]
+                    : Self.asciiCharacterCache[Int(byte)]
 
                 // Advance cursor (ASCII is always width 1)
                 if cursor.col >= columns - 1 {

--- a/ProSSHMac/Terminal/Input/KeyEncoder.swift
+++ b/ProSSHMac/Terminal/Input/KeyEncoder.swift
@@ -215,9 +215,12 @@ struct KeyEncoder: Sendable {
     }
 
     private func encodeBackspace(modifiers: KeyModifiers) -> [UInt8] {
-        // Ctrl+Backspace conventionally maps to DEL.
+        // Ctrl+Backspace sends the opposite of the normal backspace byte,
+        // so users can distinguish Ctrl+Backspace from plain Backspace.
+        // This applies regardless of whether Alt is also held (Alt adds ESC prefix).
         if modifiers.contains(.ctrl) {
-            return maybePrefixEscape([0x7F], modifiers: modifiers)
+            let ctrlByte: UInt8 = options.backspaceSendsDelete ? 0x08 : 0x7F
+            return maybePrefixEscape([ctrlByte], modifiers: modifiers)
         }
 
         let base: UInt8 = options.backspaceSendsDelete ? 0x7F : 0x08

--- a/ProSSHMac/Terminal/Parser/DCSHandler.swift
+++ b/ProSSHMac/Terminal/Parser/DCSHandler.swift
@@ -63,7 +63,7 @@ nonisolated enum DCSHandler {
     ) async {
         // Dispatch based on intermediates
         // DCS $ q ... ST = DECRQSS
-        if intermediates.contains(0x24) { // '$'
+        if intermediates == [0x24] { // '$'
             await handleDECRQSS(
                 data: data, grid: grid, responseHandler: responseHandler
             )

--- a/ProSSHMac/Terminal/Tests/SessionRecorderTests.swift
+++ b/ProSSHMac/Terminal/Tests/SessionRecorderTests.swift
@@ -9,7 +9,7 @@ import XCTest
 @MainActor
 final class SessionRecorderTests: XCTestCase {
 
-    func testRecordingPersistsEncryptedPayloadWithTimestampedChunks() throws {
+    func testRecordingPersistsEncryptedPayloadWithTimestampedChunks() async throws {
         let directory = makeTempDirectory(suffix: "persist")
         let recorder = SessionRecorder(recordingsDirectoryURL: directory)
         let session = makeSession()
@@ -19,7 +19,7 @@ final class SessionRecorderTests: XCTestCase {
         Thread.sleep(forTimeInterval: 0.002)
         recorder.recordOutput(sessionID: session.id, text: "total 64\n")
 
-        let recordingURL = try recorder.stopRecording(sessionID: session.id)
+        let recordingURL = try await recorder.stopRecording(sessionID: session.id)
 
         let raw = try Data(contentsOf: recordingURL)
         XCTAssertTrue(raw.starts(with: Data("PSSHENC1".utf8)))
@@ -56,7 +56,7 @@ final class SessionRecorderTests: XCTestCase {
         XCTAssertEqual(steps[1].text, "b")
     }
 
-    func testExportAsciinemaCastWritesHeaderAndEvents() throws {
+    func testExportAsciinemaCastWritesHeaderAndEvents() async throws {
         let directory = makeTempDirectory(suffix: "cast")
         let recorder = SessionRecorder(recordingsDirectoryURL: directory)
         let recording = SessionRecording(
@@ -73,7 +73,7 @@ final class SessionRecorderTests: XCTestCase {
             ]
         )
 
-        let castURL = try recorder.exportAsciinemaCast(
+        let castURL = try await recorder.exportAsciinemaCast(
             recording: recording,
             columns: 90,
             rows: 30,

--- a/ProSSHMac/UI/Certificates/CertificateInspectorView.swift
+++ b/ProSSHMac/UI/Certificates/CertificateInspectorView.swift
@@ -140,8 +140,7 @@ struct CertificateInspectorView: View {
 
 private func copyToClipboard(_ value: String) -> Bool {
     NSPasteboard.general.clearContents()
-    NSPasteboard.general.setString(value, forType: .string)
-    return true
+    return NSPasteboard.general.setString(value, forType: .string)
 }
 
 private struct CertificateValidityTimelineView: View {

--- a/ProSSHMac/UI/Hosts/HostsView.swift
+++ b/ProSSHMac/UI/Hosts/HostsView.swift
@@ -495,7 +495,7 @@ struct HostsView: View {
         }
 
         return groups
-            .map { (folder: $0.key, hosts: $0.value) }
+            .map { (folder: $0.key, hosts: $0.value.sorted { $0.label.localizedCaseInsensitiveCompare($1.label) == .orderedAscending }) }
             .sorted { lhs, rhs in
                 lhs.folder.localizedCaseInsensitiveCompare(rhs.folder) == .orderedAscending
             }

--- a/ProSSHMac/UI/KeyForge/KeyForgeView.swift
+++ b/ProSSHMac/UI/KeyForge/KeyForgeView.swift
@@ -118,6 +118,7 @@ struct KeyForgeView: View {
                         )
                         if imported {
                             operationMessage = "Key imported from clipboard."
+                            importLabel = ""
                             importPassphrase = ""
                         }
                     }
@@ -211,11 +212,14 @@ struct KeyForgeView: View {
                     )
                     if imported {
                         operationMessage = "Key imported from file."
+                        importLabel = ""
                         importPassphrase = ""
                     }
                 }
             case let .failure(error):
-                viewModel.errorMessage = "Unable to select key file: \(error.localizedDescription)"
+                Task { @MainActor in
+                    viewModel.errorMessage = "Unable to select key file: \(error.localizedDescription)"
+                }
             }
         }
         .alert(

--- a/ProSSHMac/UI/Settings/SettingsView.swift
+++ b/ProSSHMac/UI/Settings/SettingsView.swift
@@ -9,7 +9,7 @@ struct SettingsView: View {
     @AppStorage("terminal.effects.crtEnabled") private var terminalCRTEffectEnabled = false
     @AppStorage(BellEffectController.settingsKey) private var terminalBellFeedbackMode = BellFeedbackMode.none.rawValue
     @AppStorage(TransparencyManager.backgroundOpacityKey) private var terminalBackgroundOpacityPercent = TransparencyManager.defaultBackgroundOpacityPercent
-    @State private var allowLegacyByDefault = false
+    @AppStorage("ssh.algorithms.allowLegacyByDefault") private var allowLegacyByDefault = false
     @AppStorage("terminal.scrollback.maxLines") private var terminalScrollback = 10_000
     @AppStorage("ssh.keepalive.enabled") private var keepaliveEnabled = false
     @AppStorage("ssh.keepalive.interval") private var keepaliveInterval = 30

--- a/ProSSHMac/UI/Terminal/TerminalView.swift
+++ b/ProSSHMac/UI/Terminal/TerminalView.swift
@@ -1190,7 +1190,8 @@ struct TerminalView: View {
         }
 
         return lines.enumerated().map { index, line in
-            SafeTerminalRenderedLine(id: index, text: line)
+            let stableID = "\(index)-\(line.hashValue)"
+            return SafeTerminalRenderedLine(id: stableID, lineNumber: index, text: line)
         }
     }
 
@@ -1248,7 +1249,8 @@ struct TerminalView: View {
             for provider in providers {
                 _ = provider.loadObject(ofClass: URL.self) { url, _ in
                     guard let url else { return }
-                    let escapedPath = url.path.replacingOccurrences(of: " ", with: "\\ ")
+                    let escaped = url.path.replacingOccurrences(of: "'", with: "'\\''")
+                    let escapedPath = "'\(escaped)'"
                     Task { @MainActor in
                         await sessionManager.sendShellInput(sessionID: session.id, input: escapedPath)
                     }
@@ -1348,7 +1350,7 @@ struct TerminalView: View {
                     LazyVStack(alignment: .leading, spacing: 2) {
                         ForEach(Array(lines.enumerated()), id: \.offset) { index, line in
                             terminalLineView(line, lineIndex: index)
-                                .id(index)
+                                .id("\(index)-\(line.hashValue)")
                         }
                     }
                     .padding(8)
@@ -2354,7 +2356,8 @@ struct TerminalView: View {
 // MetalTerminalSessionSurface and MetalTerminalSurfaceModel moved to MetalTerminalSessionSurface.swift
 
 private struct SafeTerminalRenderedLine: Identifiable {
-    let id: Int
+    let id: String
+    let lineNumber: Int
     let text: String
 }
 


### PR DESCRIPTION
High severity fixes:
- Convert ForwardConnectionProxy to actor for thread safety (bug 1)
- Move waitpid to non-cooperative thread in LocalShellChannel (bug 4)
- Order certificate save before authority save for atomicity (bug 10)
- Fix Host portForwardingRules encode/decode asymmetry (bug 24)
- Add thread-safe lock + ring buffer to RendererPerformanceMonitor (bugs 43,44)
- Replace force-unwraps with safe lookups in PaneManager (bug 47)
- Move SessionRecorder file I/O to background dispatch queue (bug 49)
- Guard against empty rainbow colors array in PromptAppearance (bug 65)
- Fix MatrixScreensaverView event monitor leak and Canvas state mutation (bugs 66,67)

Medium severity fixes:
- Fix cfErrorMessage optional handling in SecureEnclaveKeyManager (bug 6)
- Convert FileKnownHostsStore from NSLock class to actor (bug 14)
- Cancel in-flight transfer tasks in TransferManager (bug 16)
- Capture working directory before cleanup in restartLocalSession (bug 20)
- Key pendingReconnectHosts by session ID instead of host ID (bug 21)
- Merge pane layout when restoring from maximized state (bug 46)
- Add balanced-parenthesis handling to LinkDetector URL regex (bug 54)
- Tighten file-path regex to require path prefix (bug 55)
- Add vertex shader bounds check and GLYPH_INDEX_NONE UV guard (bugs 58,59)
- Fix gradient glow division by zero in Metal shader (bug 61)
- Escape single quotes in file drop paths (bug 69)
- Persist allowLegacyByDefault via @AppStorage (bug 70)
- Use stable IDs for terminal display lines in SwiftUI (bug 72)
- Fix @available platform from iOS to macOS in ProSSHShortcuts (bug 79)

Low severity fixes:
- Add specific biometric error cases (bug 18)
- Guard against double cleanup in removeSession (bug 22)
- Add jump host cycle detection (bug 27)
- Guard serial number overflow (bug 28)
- Fix lastPrintedChar for charset-mapped bytes (bug 37)
- Handle multiple OSC 4 color pairs (bug 38)
- Use equality check for DECRQSS intermediates (bug 39)
- Fix Ctrl+Backspace when Alt is held (bug 41)
- Use UUID for QuickCommandVariable identity (bug 52)
- Add search match bounds validation (bug 53)
- Use weak self in IdleScreensaverManager timer (bug 57)
- Replace truncated Pi with M_PI_F in shaders (bugs 62,63)
- Fix angular discontinuity in gradient shader (bug 62)
- Return actual pasteboard write result (bug 73)
- Stable sort for ungrouped hosts (bug 74)
- Prevent charIndex overflow in MatrixScreensaverView (bug 75)
- Reset importLabel after key import (bug 76)
- Wrap state mutation in MainActor context (bug 77)

https://claude.ai/code/session_01C8yGXDZLgt7DnQu192v71N